### PR TITLE
change django to 3.2.14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 asgiref==3.5.2
-Django==4.0.5
+Django==3.2.14
 django-database-url==1.0.3
 djangorestframework==3.13.1
 mysqlclient==2.1.1


### PR DESCRIPTION
소셜로그인을 위한 dj_all_auth, django_all_auth 를 사용시 django4에서 지원하지 않는 함수들이 있음. 
따라서 3에서 가장 최신 버전인 3.2.14로 버전을 바꿈